### PR TITLE
Use uint16 for coordinates in printBMP

### DIFF
--- a/src/ATOM_PRINTER.cpp
+++ b/src/ATOM_PRINTER.cpp
@@ -77,7 +77,7 @@ void ATOM_PRINTER::printBarCode(BarCode_t type, String barcode) {
     enableBarCode(0);
 }
 
-void ATOM_PRINTER::printBMP(uint8_t mode, uint8_t xdot, uint8_t ydot,
+void ATOM_PRINTER::printBMP(uint8_t mode, uint16_t xdot, uint16_t ydot,
                             uint8_t *buffer) {
     uint8_t tmp;
     uint16_t len;

--- a/src/ATOM_PRINTER.h
+++ b/src/ATOM_PRINTER.h
@@ -40,7 +40,7 @@ class ATOM_PRINTER {
     void setQRCodeECL(QRCode_EC_Level_t level);
     void printQRCode(String qrcode);
     void printASCII(String data);
-    void printBMP(uint8_t mode, uint8_t xdot, uint8_t ydot, uint8_t *buffer);
+    void printBMP(uint8_t mode, uint16_t xdot, uint16_t ydot, uint8_t *buffer);
 };
 
 #endif


### PR DESCRIPTION
The coordinates x and y are 16bit values. They are shifted and mapped to 2 times 8 bit in the function code.